### PR TITLE
Syntax Highlighting & Formatting for Variables

### DIFF
--- a/rc/kak-dap.kak
+++ b/rc/kak-dap.kak
@@ -229,7 +229,7 @@ define-command -hidden -params 1 dap-refresh-location-flag %{
 
 define-command -hidden dap-show-stacktrace -params 1 %{
     # Show the stack trace in the stack trace buffer
-	evaluate-commands -save-regs '"' -try-client %opt[stacktraceclient] %{
+    evaluate-commands -save-regs '"' -try-client %opt[stacktraceclient] %{
         edit! -scratch *stacktrace*
         set-register '"' %arg{1}
         execute-keys Pgg
@@ -241,9 +241,20 @@ define-command -hidden dap-show-variables -params 1 %{
         edit! -scratch *variables*
         set-register '"' %arg{1}
         execute-keys Pgg
-        add-highlighter buffer/ regex "^(Scope):\s([\w\s]+)" 1:cyan 2:cyan+i
-        add-highlighter buffer/ regex "^\s+([+|-]\s)?(<\d+>)\s([^\s]+)\s\(([A-Za-z]+)\)" 2:comment 3:variable 4:type
         map buffer normal '<ret>' ':<space>dap-expand-variable<ret>'
+
+        # strings, keep first
+        add-highlighter buffer/vals regions
+        add-highlighter buffer/vals/double_string region '"'  (?<!\\)(\\\\)*" fill string
+        add-highlighter buffer/vals/single_string region "'"  (?<!\\)(\\\\)*' fill string
+        # Scope and varialbe lines
+        add-highlighter buffer/scope regex "^(Scope):\s([\w\s]+)" 2:attribute
+        add-highlighter buffer/variable_line regex "^\s+([+|-]\s)?(<\d+>)\s([^\s]+)\s\(([A-Za-z]+)\)" 2:comment 3:variable 4:type
+        # values
+        add-highlighter buffer/type_num regex "(-?\d+)$" 1:value
+        add-highlighter buffer/type_bool regex "((?i)true|false)$" 0:value
+        add-highlighter buffer/type_null regex "((?i)null|nil|undefined)$" 0:keyword
+        add-highlighter buffer/type_array regex "(array\(\d+\))$" 0:function
     }
 }
 

--- a/rc/kak-dap.kak
+++ b/rc/kak-dap.kak
@@ -241,6 +241,8 @@ define-command -hidden dap-show-variables -params 1 %{
         edit! -scratch *variables*
         set-register '"' %arg{1}
         execute-keys Pgg
+        add-highlighter buffer/ regex "^(Scope):\s([\w\s]+)" 1:cyan 2:cyan+i
+        add-highlighter buffer/ regex "^\s+([+|-]\s)?(<\d+>)\s([^\s]+)\s\(([A-Za-z]+)\)" 2:comment 3:variable 4:type
         map buffer normal '<ret>' ':<space>dap-expand-variable<ret>'
     }
 }

--- a/rc/kak-dap.kak
+++ b/rc/kak-dap.kak
@@ -254,7 +254,7 @@ define-command -hidden dap-show-variables -params 1 %{
         add-highlighter buffer/type_num regex "(-?\d+)$" 1:value
         add-highlighter buffer/type_bool regex "((?i)true|false)$" 0:value
         add-highlighter buffer/type_null regex "((?i)null|nil|undefined)$" 0:keyword
-        add-highlighter buffer/type_array regex "(array\(\d+\))$" 0:function
+        add-highlighter buffer/type_array regex "(array\(\d+\))$" 0:default+i
     }
 }
 

--- a/src/stack_trace.rs
+++ b/src/stack_trace.rs
@@ -29,7 +29,7 @@ pub fn handle_stack_trace_response(msg: json::JsonValue, ctx: &mut Context) {
     cmd.push_str(" ");
     cmd.push_str(&file.to_string());
     cmd.push_str(" ");
-    cmd.push_str("'Stack Trace:\n\n");
+    cmd.push_str("'");
     // Add contents to push to stacktrace buffer
     let frame_members = frames.members();
     for val in frame_members {

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -72,7 +72,7 @@ pub fn handle_variables_response(msg: json::JsonValue, ctx: &mut Context) {
 
 // Constructs the command that renders all the scopes and variables in the variables buffer.
 pub fn serialize_variables(ctx: &mut Context) {
-    let mut cmd = "dap-show-variables 'Variables:\n\n".to_string();
+    let mut cmd = "dap-show-variables '".to_string();
     let mut cmd_val = "".to_string();
     for scope in &ctx.scopes {
         let scope_name = &scope.contents["name"];
@@ -88,7 +88,7 @@ pub fn serialize_variables(ctx: &mut Context) {
             }
         }
         if has_child {
-            let val = serialize_variable(ctx, scope.variable_reference, 4);
+            let val = serialize_variable(ctx, scope.variable_reference, 2);
             cmd_val.push_str(&val);
         }
     }
@@ -100,6 +100,7 @@ pub fn serialize_variables(ctx: &mut Context) {
 // Constructs the command that renders all the child variables of the given variable reference in the variables buffer.
 pub fn serialize_variable(ctx: &Context, par_ref: u64, indent: u64) -> String {
     let mut val = "".to_string();
+    let mut icon = " ";
     for var in &ctx.variables {
         if var.par_variable_reference == par_ref {
             for _i in 0..indent {
@@ -107,7 +108,7 @@ pub fn serialize_variable(ctx: &Context, par_ref: u64, indent: u64) -> String {
             }
             // If this variable is expandable
             if var.variable_reference > 0 {
-                let mut icon = "+";
+                icon = "+";
                 // Determine if this variable has any child variables currently
                 for varr in &ctx.variables {
                     if varr.par_variable_reference == var.variable_reference {
@@ -115,8 +116,8 @@ pub fn serialize_variable(ctx: &Context, par_ref: u64, indent: u64) -> String {
                         break;
                     }
                 }
-                val.push_str(&format!("{} ", icon));
             }
+            val.push_str(&format!("{} ", icon));
             val.push_str("<");
             val.push_str(&var.variable_reference.to_string());
             val.push_str("> ");
@@ -127,7 +128,7 @@ pub fn serialize_variable(ctx: &Context, par_ref: u64, indent: u64) -> String {
             val.push_str(&var.contents["value"].to_string());
             val.push_str("\n");
             if var.variable_reference > 0 {
-                val.push_str(&serialize_variable(ctx, var.variable_reference, indent + 4));
+                val.push_str(&serialize_variable(ctx, var.variable_reference, indent + 2));
             }
         }
     }


### PR DESCRIPTION
Hello @jdugan6240,

To make it easier to read, I have added some syntax highlighting for the variables. Stacktrace could be done as well, but I barely use it, and can get to it with some time. Here are some quick notes, as I have made some changes to the output of both vars/stack (first edits in Rust!):

* Removed the first line of text for both, "Variables:" and "Stacktrace:", found it redundant and most other output that goes to docs/tools client never includes this.
* Aligned the variables a bit better -- to ensure they line up properly, and a little less indentation for heavily nested items
* Included common value types
* FYI -- used default face for array(X), just pushed (forgot) so they don't appear colored (as the screenshots), just italic

Here are screenshots, I am using named faces which are common and will work with any colorscheme:

![screenshot_2022 07 19_192840](https://user-images.githubusercontent.com/1596691/179870356-4bef8f58-eb35-4096-abca-1b02d6ffda01.png)

![screenshot_2022 07 19_192821](https://user-images.githubusercontent.com/1596691/179870366-37d02bb4-3dc1-4a8b-a2a7-8944cb64f119.png)

